### PR TITLE
fix: deprecated function ioutil

### DIFF
--- a/library/helper.go
+++ b/library/helper.go
@@ -3,7 +3,6 @@ package library
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -13,7 +12,7 @@ import (
 
 // Read File
 func ReadFile(path string) []byte {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/library/markdown.go
+++ b/library/markdown.go
@@ -2,7 +2,6 @@ package library
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -53,7 +52,7 @@ func MarkdownGenerateFileTree(path string, ignore []string) string {
 	ignore = append(ignore, ".git", ".github", ".vscode", ".idea", ".obsidian", ".gitignore", ".gitkeep", ".DS_Store")
 
 	// Read the directory
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return ""
 	}

--- a/library/php.go
+++ b/library/php.go
@@ -3,7 +3,6 @@ package library
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -166,7 +165,7 @@ func listFunctionCalls(path string, filters []string) []FunctionObject {
 		}
 		if filepath.Ext(filePath) == ".php" {
 			// Read the file
-			bs, err := ioutil.ReadFile(filePath)
+			bs, err := os.ReadFile(filePath)
 			if err != nil {
 				panic(err)
 			}

--- a/library/phpcs.go
+++ b/library/phpcs.go
@@ -3,7 +3,6 @@ package library
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,7 +35,7 @@ func phpCSGetConfig() (PHPCSConfig, error) {
 	configPath := dir + "/config.json"
 
 	// Read the contents of the config file.
-	configData, err := ioutil.ReadFile(configPath)
+	configData, err := os.ReadFile(configPath)
 	if err != nil {
 		fmt.Println("❌", err)
 		return PHPCSConfig{}, err
@@ -68,7 +67,7 @@ func phpCSDetectStandard() ([]string, error) {
 	standardsJSON := dir + "/standards.json"
 
 	// Read standards.json file
-	bytes, err := ioutil.ReadFile(standardsJSON)
+	bytes, err := os.ReadFile(standardsJSON)
 	if err != nil {
 		return standards, err
 	}
@@ -86,7 +85,7 @@ func phpCSDetectStandard() ([]string, error) {
 		standards = append(standards, standardDirectory)
 
 		// List all subdirectories in standards directory
-		subdirectories, err := ioutil.ReadDir(standardDirectory)
+		subdirectories, err := os.ReadDir(standardDirectory)
 		if err != nil {
 			return standards, err
 		}


### PR DESCRIPTION
## Fixes Issue
File read and write error on Windows because of deprecated library ioutil.

## Changes proposed
Remove import library `"io/ioutil"` then change to `ioutil.` to `os.`.

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![remove-link-md](https://github.com/artistudioxyz/aspri/assets/24585708/f88cdbfb-56f9-4cfe-a3d0-32ca1e330c1c)


## Note to reviewers
Already tested on my Windows, it's working well.
