### PR TITLE
fix: DirectoryStats Obsidian total files calculation error

### DIFF
--- a/library/directory.go
+++ b/library/directory.go
@@ -14,7 +14,7 @@ import (
 func InitiateDirectoryFunction(flags Flag) {
 	/** Directory Stats */
 	if *flags.Dir && *flags.Stats {
-		DirectoryStats(*flags.Path, true)
+		DirectoryStats(*flags.Path, true, *flags.Exclude)
 	}
 	/** remove Directories Older than days matching regex */
 	if *flags.Dir && *flags.Remove && *flags.OlderThan && *flags.Days > 0 {
@@ -37,7 +37,7 @@ func GetDepth(path string, dirPath string) int {
 }
 
 /** Directory Stats */
-func DirectoryStats(path string, print bool) (int, int64, int64, map[string]int, int, int) {
+func DirectoryStats(path string, print bool, exclude []string) (int, int64, int64, map[string]int, int, int) {
 	if path == "" {
 		CurrentDirectory, _ := os.Getwd()
 		path = CurrentDirectory
@@ -49,18 +49,16 @@ func DirectoryStats(path string, print bool) (int, int64, int64, map[string]int,
 	var lineCount int
 	var wordCount int
 
-	excludedDirs := []string{".stversions", ".obsidian"}
-
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			fmt.Println("❌ Error:", err)
 			return err
 		}
 
-		// Skip the excluded directories
-		for _, excludedDir := range excludedDirs {
-			if info.IsDir() && strings.Contains(path, excludedDir) {
-				return filepath.SkipDir
+		// Check if the directory should be ignored
+		for _, excludeDir := range exclude {
+			if strings.Contains(path, excludeDir) {
+				return nil
 			}
 		}
 

--- a/library/directory.go
+++ b/library/directory.go
@@ -49,10 +49,19 @@ func DirectoryStats(path string, print bool) (int, int64, int64, map[string]int,
 	var lineCount int
 	var wordCount int
 
+	excludedDirs := []string{".stversions", ".obsidian"}
+
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			fmt.Println("❌ Error:", err)
 			return err
+		}
+
+		// Skip the excluded directories
+		for _, excludedDir := range excludedDirs {
+			if info.IsDir() && strings.Contains(path, excludedDir) {
+				return filepath.SkipDir
+			}
 		}
 
 		if !info.IsDir() {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

DirectoryStats Obsidian Total Files Calculation Error #7

<!-- Example: Closes #31 -->

## Changes proposed

- [x] Adding excludedDirs to select which folders should not be counted.


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

--

## Note to reviewers

--
